### PR TITLE
Fixed crash if a sector references a non-existent svg

### DIFF
--- a/BuilderPlug.cs
+++ b/BuilderPlug.cs
@@ -596,6 +596,13 @@ namespace CodeImp.DoomBuilder.ThreeDFloorMode
 				List<Vector3D> sp = new List<Vector3D>();
 				SlopeVertexGroup svg = GetSlopeVertexGroup(id);
 
+                //if the dbs file was deleted or corrupted and the svg info is not available, then unbind the svg info from this sector
+                if (svg == null)
+                {
+                    s.Fields.Remove(fn);
+                    continue;
+                }
+
 				for (int i = 0; i < svg.Vertices.Count; i++)
 				{
 					sp.Add(new Vector3D(svg.Vertices[i].Pos.x, svg.Vertices[i].Pos.y, svg.Vertices[i].Z));


### PR DESCRIPTION
The crash occurs when attempting to add a new slope to a sector that references a non-existant svg.

Notably, this occurs when the dbs file is either deleted or corrupted.