### PR TITLE
Fixes and QOL Changes

### DIFF
--- a/DrawSlopesMode.cs
+++ b/DrawSlopesMode.cs
@@ -186,31 +186,44 @@ namespace CodeImp.DoomBuilder.ThreeDFloorMode
 			{
 				for (int i = 0; i < svg.Vertices.Count; i++)
 				{
-					SlopeVertex sv = svg.Vertices[i];
-					float x = sv.Pos.x;
-					float y = sv.Pos.y - 14 * (1 / renderer.Scale);
-
-					TextLabel label = new TextLabel();
-					label.TransformCoords = true;
-					label.Location = new Vector2D(x, y);
-					label.AlignX = TextAlignmentX.Center;
-					label.AlignY = TextAlignmentY.Middle;
-					label.BackColor = General.Colors.Background.WithAlpha(255);
-					label.Text = "";
-
-					// Rearrange labels if they'd be (exactly) on each other
-					// TODO: do something like that also for overlapping labels
-					foreach (TextLabel l in labels)
+					if (BuilderPlug.Me.SlopeVertexLabelDisplayOption == LabelDisplayOption.Always || General.Interface.AltState == true)
 					{
-						if (l.Location.x == label.Location.x && l.Location.y == label.Location.y)
-							label.Location = new Vector2D(x, l.Location.y - 14.0f * (1 / renderer.Scale));
+						SlopeVertex sv = svg.Vertices[i];
+						float scale = 1 / renderer.Scale;
+						float x = sv.Pos.x;
+						float y = sv.Pos.y - 14 * scale;
+						string value = String.Format("Z: {0}", sv.Z);
+						bool showlabel = true;
+
+						// Rearrange labels if they'd be (exactly) on each other
+						foreach (TextLabel l in labels)
+						{
+							if (l.Location.x == x && l.Location.y == y) {
+								// Reduce visual clutter by de-duping stacked labels, when "show all labels" is enabled
+								if (l.Text == value) {
+									showlabel = false; //dedupe
+								} else {
+									// Adjust the label position down one line
+									y -= l.TextSize.Height * scale;
+								}
+							}
+						}
+
+						// Only proceed if the label was not deduped
+						if (showlabel)
+						{
+							TextLabel label = new TextLabel();
+							label.TransformCoords = true;
+							label.Location = new Vector2D(x, y);
+							label.AlignX = TextAlignmentX.Center;
+							label.AlignY = TextAlignmentY.Middle;
+							label.BackColor = General.Colors.Background.WithAlpha(128);
+							label.Text = value;
+							label.Color = white;
+
+							labels.Add(label);
+						}
 					}
-
-					label.Color = white;
-
-					label.Text += String.Format("Z: {0}", sv.Z);
-
-					labels.Add(label);
 				}
 			}
 		}

--- a/SlopeVertexGroup.cs
+++ b/SlopeVertexGroup.cs
@@ -138,7 +138,15 @@ namespace CodeImp.DoomBuilder.ThreeDFloorMode
 			}
 		}
 
-		public void RemoveFromSectors()
+        public void RemovePlanes()
+        {
+            foreach (Sector s in sectors.ToList())
+            {
+                RemoveSector(s, this.sectorplanes[s]);
+            }
+        }
+
+        public void RemoveFromSectors()
 		{
 			foreach (Sector s in sectors.ToList())
 			{

--- a/ThreeDFloorMode.csproj
+++ b/ThreeDFloorMode.csproj
@@ -52,7 +52,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>..\GZDoom-Builder-Bugfix\Build\Plugins\</OutputPath>
+    <OutputPath>..\..\..\Build\Plugins\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>
@@ -211,15 +211,16 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\GZDoom-Builder-Bugfix\Source\Core\Builder.csproj">
+    <ProjectReference Include="..\..\Core\Builder.csproj">
       <Project>{818b3d10-f791-4c3f-9af5-bb2d0079b63c}</Project>
       <Name>Builder</Name>
+      <Private>False</Private>
     </ProjectReference>
-    <ProjectReference Include="..\GZDoom-Builder-Bugfix\Source\Plugins\BuilderEffects\BuilderEffects.csproj">
+    <ProjectReference Include="..\BuilderEffects\BuilderEffects.csproj">
       <Project>{b859be0f-a992-476d-a642-fa8efe94aaa5}</Project>
       <Name>BuilderEffects</Name>
     </ProjectReference>
-    <ProjectReference Include="..\GZDoom-Builder-Bugfix\Source\Plugins\BuilderModes\BuilderModes.csproj">
+    <ProjectReference Include="..\BuilderModes\BuilderModes.csproj">
       <Project>{b42d5aa0-f9a6-4234-9c4b-a05b11a64851}</Project>
       <Name>BuilderModes</Name>
     </ProjectReference>

--- a/Windows/ThreeDFloorEditorWindow.cs
+++ b/Windows/ThreeDFloorEditorWindow.cs
@@ -106,7 +106,7 @@ namespace CodeImp.DoomBuilder.ThreeDFloorMode
 			ThreeDFloorHelperControl dup = GetThreeDFloorControl();
 
 			dup.Update(ctrl);
-			ctrl.Show();
+			dup.Show();
 
 			threeDFloorPanel.ScrollControlIntoView(dup);
 		}


### PR DESCRIPTION
Fixed a few bugs, and added some quality of life changes:

* Fixed duplicate button not properly updating the controls
* Fixed paired slope getting unbound from the sector when removing only one of them
* Updated project build output to follow the same relative path as other plugins
* Updated project so that the builder exe and dll deps are not incorrectly copied into the plugins output directory
* QOL: If multiple slope handles are positioned at the same location, and two or more of them have the same z-height, only one label will be shown (de-duplication)
* QOL: It is now possible to cycle through slope handles that are bound to the same location by using the cycle 3d floor keys