### PR TITLE
More QOL Changes

### DIFF
--- a/Controls/ThreeDFloorControl.cs
+++ b/Controls/ThreeDFloorControl.cs
@@ -83,7 +83,6 @@ namespace CodeImp.DoomBuilder.ThreeDFloorMode
 			typeArgument.Setup(General.Map.Config.LinedefActions[160].Args[1]);
 			flagsArgument.Setup(General.Map.Config.LinedefActions[160].Args[2]);
 			alphaArgument.Setup(General.Map.Config.LinedefActions[160].Args[3]);
-			sectorBrightness.Text = General.Settings.DefaultBrightness.ToString();
 
 			typeArgument.SetDefaultValue();
 			flagsArgument.SetDefaultValue();
@@ -96,19 +95,30 @@ namespace CodeImp.DoomBuilder.ThreeDFloorMode
 			for (int i = 0; i < checkedListBoxSectors.Items.Count; i++)
 				checkedListBoxSectors.SetItemChecked(i, true);
 
-			//When creating a NEW 3d sector, find the sector that is the tallest, and place the floor on top of it
+			//When creating a NEW 3d sector, find information about what is selected to populate the defaults
 			int FloorHeight = int.MinValue;
+			int SectorDarkest = int.MaxValue;
 			foreach (Sector s in BuilderPlug.TDFEW.SelectedSectors)
 			{
 				if (s.FloorHeight > FloorHeight)
 					FloorHeight = s.FloorHeight;
+				if (s.Brightness < SectorDarkest)
+					SectorDarkest = s.Brightness;
 			}
 
+			//set the floor height to match the lowest sector selected, then offset the height by the configured default
 			if (FloorHeight != int.MinValue)
 			{
 				int DefaultHeight = General.Settings.DefaultCeilingHeight - General.Settings.DefaultFloorHeight;
 				sectorFloorHeight.Text = FloorHeight.ToString();
 				sectorCeilingHeight.Text = (FloorHeight + DefaultHeight).ToString();
+			}
+
+			//set the brightness to match the darkest of all the selected sectors by default
+			if (SectorDarkest != int.MaxValue) {
+				sectorBrightness.Text = SectorDarkest.ToString();
+			} else {
+				sectorBrightness.Text = General.Settings.DefaultBrightness.ToString();
 			}
 
 			sector = General.Map.Map.CreateSector();

--- a/SlopeVertexGroup.cs
+++ b/SlopeVertexGroup.cs
@@ -77,7 +77,7 @@ namespace CodeImp.DoomBuilder.ThreeDFloorMode
 			}
 
 			// Get reposition value
-			reposition = sector.Fields.GetValue(String.Format("user_svg{0}_reposition", id), false);
+			reposition = sector.Fields.GetValue(String.Format("user_svg{0}_reposition", id), true);
 
 			ComputeHeight();
 			FindSectors();
@@ -314,15 +314,16 @@ namespace CodeImp.DoomBuilder.ThreeDFloorMode
 			// Add, update, or delete the reposition field
 			if (reposition)
 			{
+				//default action
 				if (sector.Fields.ContainsKey(identifier))
-					sector.Fields[identifier] = new UniValue(UniversalType.Boolean, reposition);
-				else
-					sector.Fields.Add(identifier, new UniValue(UniversalType.Boolean, reposition));
+					sector.Fields.Remove(identifier);
 			}
 			else
 			{
 				if (sector.Fields.ContainsKey(identifier))
-					sector.Fields.Remove(identifier);
+					sector.Fields[identifier] = new UniValue(UniversalType.Boolean, reposition);
+				else
+					sector.Fields.Add(identifier, new UniValue(UniversalType.Boolean, reposition));
 			}
 		}
 

--- a/Windows/SlopeVertexEditForm.Designer.cs
+++ b/Windows/SlopeVertexEditForm.Designer.cs
@@ -124,14 +124,15 @@
 			// positionz
 			// 
 			this.positionz.AllowDecimal = true;
+			this.positionz.AllowExpressions = false;
 			this.positionz.AllowNegative = true;
 			this.positionz.AllowRelative = true;
 			this.positionz.BackColor = System.Drawing.Color.Transparent;
 			this.positionz.ButtonStep = 8;
-			this.positionz.ButtonStepBig = 10F;
-			this.positionz.ButtonStepFloat = 1F;
-			this.positionz.ButtonStepSmall = 0.1F;
-			this.positionz.ButtonStepsUseModifierKeys = false;
+			this.positionz.ButtonStepBig = 16F;
+			this.positionz.ButtonStepFloat = 8F;
+			this.positionz.ButtonStepSmall = 1F;
+			this.positionz.ButtonStepsUseModifierKeys = true;
 			this.positionz.ButtonStepsWrapAround = false;
 			this.positionz.Location = new System.Drawing.Point(29, 82);
 			this.positionz.Name = "positionz";
@@ -142,14 +143,15 @@
 			// positiony
 			// 
 			this.positiony.AllowDecimal = true;
+			this.positiony.AllowExpressions = false;
 			this.positiony.AllowNegative = true;
 			this.positiony.AllowRelative = true;
 			this.positiony.BackColor = System.Drawing.Color.Transparent;
 			this.positiony.ButtonStep = 8;
-			this.positiony.ButtonStepBig = 10F;
-			this.positiony.ButtonStepFloat = 1F;
-			this.positiony.ButtonStepSmall = 0.1F;
-			this.positiony.ButtonStepsUseModifierKeys = false;
+			this.positiony.ButtonStepBig = 16F;
+			this.positiony.ButtonStepFloat = 8F;
+			this.positiony.ButtonStepSmall = 1F;
+			this.positiony.ButtonStepsUseModifierKeys = true;
 			this.positiony.ButtonStepsWrapAround = false;
 			this.positiony.Location = new System.Drawing.Point(29, 52);
 			this.positiony.Name = "positiony";
@@ -160,14 +162,15 @@
 			// positionx
 			// 
 			this.positionx.AllowDecimal = true;
+			this.positionx.AllowExpressions = false;
 			this.positionx.AllowNegative = true;
 			this.positionx.AllowRelative = true;
 			this.positionx.BackColor = System.Drawing.Color.Transparent;
 			this.positionx.ButtonStep = 8;
-			this.positionx.ButtonStepBig = 10F;
-			this.positionx.ButtonStepFloat = 1F;
-			this.positionx.ButtonStepSmall = 0.1F;
-			this.positionx.ButtonStepsUseModifierKeys = false;
+			this.positionx.ButtonStepBig = 16F;
+			this.positionx.ButtonStepFloat = 8F;
+			this.positionx.ButtonStepSmall = 1F;
+			this.positionx.ButtonStepsUseModifierKeys = true;
 			this.positionx.ButtonStepsWrapAround = false;
 			this.positionx.Location = new System.Drawing.Point(29, 20);
 			this.positionx.Name = "positionx";


### PR DESCRIPTION
* When drawing a new slope for a 3d floor, the Z height of the SVG will now match the 3d floor's control sector. Previously, it would always use the sector the handle was in.
* When creating a new 3d floor, the initial brightness value will be set to the darkest of all the selected sectors. Previously, it would always default to the map defaults. Now, it takes what you selected into consideration.
* The "reposition when dragging" checkbox is now checked by default. Note: this will state flip already created handles. It makes more sense to have this functionality enabled by default. It becomes clunky, otherwise, to have to constantly remember to turn this flag on for each new handle created. Due to the way the setting is stored (by not writing the user var if its in default mode), there isnt really a good way to support giving the user a choice of preferred default.
* The numeric up/down boxes on the svg edit window is now consistent with the other up/down boxes used by core. E.g: normal tick is 8, big tick is 16, small tick is 1.